### PR TITLE
update to latest release of branch-names

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -44,7 +44,7 @@ jobs:
       ##################### BEGIN boilerplate steps #####################
       - name: Get branch names
         id: branch-name
-        uses: tj-actions/branch-names@v5.4
+        uses: tj-actions/branch-names@v6.4
       
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION
https://github.com/tj-actions/branch-names

Update from v5.4 with `set-output` to v6.4, mentioned in https://github.com/tj-actions/branch-names/issues/180.

Closes #78 