### PR TITLE
updates for warnings/clarity

### DIFF
--- a/R/check_ae_fatal.R
+++ b/R/check_ae_fatal.R
@@ -97,7 +97,7 @@
 #'
 #' check_ae_fatal(AE)
 #'
-#' # AETOXGR, existing but unmapped AESEV
+#' # AETOXGR exists but unmapped AESEV
 #'
 #'  AE <- data.frame(
 #'  USUBJID = 1:5,
@@ -115,64 +115,92 @@
 #' check_ae_fatal(AE)
 #' check_ae_fatal(AE,preproc=roche_derive_rave_row)
 #'
+#' # AETOXGR and AESEV exist, by both are unmapped
+#'
+#'  AE <- data.frame(
+#'  USUBJID = 1:5,
+#'  AESTDTC = "01JAN2017",
+#'  AEDECOD = c("AE1","AE2","AE3","AE4","AE5"),
+#'  AEOUT = "FATAL",
+#'  AEDTHDTC = c("01FEB2017",NA,"02FEB2017","03FEB2017",NA),
+#'  AESDTH = c("Y","Y","N","Y",NA),
+#'  AESEV = NA,
+#'  AETOXGR = NA,
+#'  AESPID = "FORMNAME-R:12/L:2XXXX",
+#'  stringsAsFactors = FALSE
+#' )
+#'
+#' check_ae_fatal(AE)
+#' check_ae_fatal(AE,preproc=roche_derive_rave_row)
+#'
 
 
 ## Check for missing death dates when ae outcomes are fatal.
-## Note, in a case where both AETOXGR and AESEV exist and some records are supposed to have AETOXGR populated while others have AESEV (ie mutaually exlusive)
+## Note, in a case where both AETOXGR and AESEV exist and some records are supposed to have AETOXGR populated while others have AESEV (ie mutually exclusive)
 ## Then this check will likely return false positives as it expects a variable to be populated for all records
 
 check_ae_fatal <- function(AE,preproc=identity,...){
-
+  
   ###First check that required variables exist and return a message if they don't
   if(AE %lacks_any% c("USUBJID", "AEDECOD", "AESTDTC","AEDTHDTC", "AEOUT", "AESDTH")){
-
-      fail(lacks_msg(AE, c("USUBJID", "AEDECOD", "AESTDTC", "AEDTHDTC", "AEOUT", "AESDTH")))
-
+    
+    fail(lacks_msg(AE, c("USUBJID", "AEDECOD", "AESTDTC", "AEDTHDTC", "AEOUT", "AESDTH")))
+    
   } else{
-
+    
     #Apply company specific preprocessing function
     AE = preproc(AE,...)
-
+    
     outlist=list() #empty list for results
-
+    
     # check if AEOUT=='FATAL' that there is a corresponding AEDTHDTC, death date
-
-    if(AE %has_any% "AETOXGR" & !all(is_sas_na(AE$AETOXGR))){ #Non-empty AETOXGR exists
-
-    outlist[[1]] = AE %>%
-      filter(AEOUT=='FATAL' & (is_sas_na(AEDTHDTC) | AETOXGR !=5 | is_sas_na(AETOXGR) | AESDTH != "Y" | is_sas_na(AESDTH)))
+    
+    #1. AETOXGR exists and is populated
+    if(AE %has_any% "AETOXGR"){ #if var exists
+      if(!all(is_sas_na(AE$AETOXGR))){ #Only run check if var is mapped
+        outlist[[1]] = AE %>%
+          filter(AEOUT=='FATAL' & (is_sas_na(AEDTHDTC) | AETOXGR !=5 | is_sas_na(AETOXGR) | AESDTH != "Y" | is_sas_na(AESDTH)))
+      }
     }
-
-    if(AE %has_any% "AESEV" & !all(is_sas_na(AE$AESEV))){ #Non-empty AESEV exists
-
-    outlist[[2]] <- AE %>%
+    
+    #2. AESEV exists and is populated
+    if(AE %has_any% "AESEV"){ #if var exists
+      if(!all(is_sas_na(AE$AESEV))){#Only run check if var is mapped
+        outlist[[2]] <- AE %>%
           filter(AEOUT=='FATAL' & (is_sas_na(AEDTHDTC) | AESEV != "SEVERE" | AESDTH != "Y" | is_sas_na(AESDTH)))
-
+      }
     }
-
-    #Neither of Non-empty AESEV/AETOXGR exists
-    #ie Both AESEV/AETOXGR don't exists or one or more exists but is not mapped
-
-    if(!(AE %has_any% "AESEV" & !all(is_sas_na(AE$AESEV))) & !(AE %has_any% "AETOXGR" & !all(is_sas_na(AE$AETOXGR)))){
-
-    outlist[[3]] <- AE %>%
+    
+    #3. If neither AETOXGR or AESEV exist
+    if(!(AE %has_any% "AESEV" & AE %has_any% "AETOXGR")){
+      outlist[[3]] <- AE %>%
+        filter(AEOUT=='FATAL' & (is_sas_na(AEDTHDTC) | AESDTH != "Y" | is_sas_na(AESDTH)))
+    }
+    
+    #4. If both AETOXGR or AESEV exist but both are not populated
+    if((AE %has_any% "AESEV" & AE %has_any% "AETOXGR")){
+      if(all(is_sas_na(AE$AESEV)) & all(is_sas_na(AE$AESEV))){#Only run check if var is mapped
+        outlist[[4]] <- AE %>%
           filter(AEOUT=='FATAL' & (is_sas_na(AEDTHDTC) | AESDTH != "Y" | is_sas_na(AESDTH)))
+      }
     }
-
+    
+    
+    
     mydf = bind_rows(outlist)
     # leave only variables on which we want to check for fatalities and their corresponding death dates
     mydf = unique(mydf[,intersect(names(AE),c("STUDYID","USUBJID", "AEDECOD", "AESTDTC","AEDTHDTC", "AEOUT","AESEV","AETOXGR","AESDTH","RAVE"))])
     rownames(mydf)=NULL
-
+    
     ### Return message if no inconsistency between AEOUT and AEDTHDTC
     if(nrow(mydf)==0){
       pass()
-
+      
       ### Return subset dataframe if there are records with inconsistency
     }else if(nrow(mydf)>0){
-
+      
       fail(paste("AE has ",length(unique(mydf$USUBJID))," patient(s) with AE death variable inconsistencies when outcome marked FATAL. ",sep=""), mydf)
-
+      
     }
   }
 }

--- a/tests/testthat/test-check_ae_fatal.R
+++ b/tests/testthat/test-check_ae_fatal.R
@@ -152,3 +152,27 @@ test_that("Function returns the failed object in attr(data)", {
 })
 
 
+test_that("function returns false when errors are present", {
+    
+    AE <- data.frame(
+        USUBJID = 1:5,
+        AESTDTC = "01JAN2017",
+        AEDECOD = c("AE1","AE2","AE3","AE4","AE5"),
+        AEOUT = "FATAL",
+        AEDTHDTC = c("01FEB2017",NA,"02FEB2017","03FEB2017",NA),
+        AESDTH = c("Y","Y","N","Y",NA),
+        AESEV = NA,
+        AETOXGR = NA,
+        AESPID = "FORMNAME-R:12/L:2XXXX",
+        stringsAsFactors = FALSE
+    )
+    
+    expect_false(check_ae_fatal(AE))
+    
+})
+
+
+
+
+
+


### PR DESCRIPTION
`check_ae_fatal` was kicking out some warnings.  This was because the same `if()` clause checked for the existence of a variable at the same time as referencing it, e.g.:

````
if("AESEV" %in% names(AE) & AE$AESEV != ""){
...
}
```

I think SAS allows this but it seems to be a no no in R.  Code updated to instead first check for existence of variable then check to see if its missing.  Also the logic of this check was a little hard to follow so I updated it for clarity.