### PR TITLE
run_all_checks alerts if no "covid_df"

### DIFF
--- a/R/run_all_checks.R
+++ b/R/run_all_checks.R
@@ -96,7 +96,7 @@ run_all_checks <- function(metads = sdtmchecksmeta,
     cat("\n")
     
     if(!("covid_df" %in% ls(envir = .GlobalEnv))){
-      warning("An object named 'covid_df' was not found in your global environment. The following checks were not run: 
+      warning("An object named 'covid_df' was not found in your global environment so the following checks were not run: 
               check_ae_aeacn_ds_disctx_covid
               check_ae_aeacnoth_ds_stddisc_covid
               check_dv_ae_aedecod_covid")

--- a/R/run_all_checks.R
+++ b/R/run_all_checks.R
@@ -91,7 +91,16 @@ run_all_checks <- function(metads = sdtmchecksmeta,
                 ". Checks requiring this domain were not run."
             )
         )
-        }
+    }
+    
+    cat("\n")
+    
+    if(!("covid_df" %in% ls(envir = .GlobalEnv))){
+      warning("An object named 'covid_df' was not found in your global environment. The following checks were not run: 
+              check_ae_aeacn_ds_disctx_covid
+              check_ae_aeacnoth_ds_stddisc_covid
+              check_dv_ae_aedecod_covid")
+    }
     
   cat("\n")
     


### PR DESCRIPTION
message from individual functions doesn't make it to console if `covid_df` is missing when running `run_all_checks`.  Maybe suppressed by mcapply?  Add a quick check to `run_all_checks`