### PR TITLE
dont dup with SPID, do dup with VISIT, add RAVE

### DIFF
--- a/R/check_tr_dup.R
+++ b/R/check_tr_dup.R
@@ -47,9 +47,9 @@
 
 check_tr_dup <- function(TR,preproc=identity,...){
     
-    if (TR %lacks_any% c("USUBJID","TRCAT","TRTESTCD","TRDTC","TRSTRESC","VISIT")){
+    if (TR %lacks_any% c("USUBJID","TRCAT","TRTESTCD","TRDTC","TRSTRESC","VISIT","TRGRPID")){
         
-        fail (lacks_msg(TR, c("USUBJID","TRCAT","TRTESTCD","TRDTC","TRSTRESC","VISIT")))
+        fail (lacks_msg(TR, c("USUBJID","TRCAT","TRTESTCD","TRDTC","TRSTRESC","VISIT","TRGRPID")))
         
     } else if (TR %lacks_all% c("TRLINKID", "TRLNKID")) {
         
@@ -60,9 +60,9 @@ check_tr_dup <- function(TR,preproc=identity,...){
         #Apply company specific preprocessing function
         TR = preproc(TR,...)
         
-        myvars <- c("USUBJID","TRCAT","TRTESTCD",names(TR)[names(TR) %in% c("TRLINKID","TRLNKID")],
+        myvars <- c("USUBJID","TRCAT","TRGRPID","TRTESTCD",names(TR)[names(TR) %in% c("TRLINKID","TRLNKID")],
                     # names(TR)[names(TR) %in% "TRSPID"],
-                    "TRDTC","TRSTRESC","VISIT")
+                    "TRDTC","VISIT","TRSTRESC")
         
         if(TR %lacks_any% "TREVAL"){
             
@@ -88,13 +88,11 @@ check_tr_dup <- function(TR,preproc=identity,...){
         
         # duplicate TR records
         dups <- subset(tr1, duplicated(tr1), myvars) %>%
-            unique() %>% 
-            left_join((TR %>% select(any_of(c(myvars,"RAVE")))),by=myvars,relationship = "many-to-many") %>% 
-            unique
+            unique()
         rownames(dups)=NULL
         
         # declare number of duplicated TR records and print them
-        n0 <- paste('There are ', (dups %>% select(any_of(myvars)) %>% unique %>% nrow), ' duplicated TR records. ', sep ='')
+        n0 <- paste('There are ', (dups %>% nrow), ' duplicated TR records. ', sep ='')
         
         if (nrow(dups) == 0){
             pass()

--- a/R/check_tr_dup.R
+++ b/R/check_tr_dup.R
@@ -6,8 +6,6 @@
 #'
 #' @param TR dataframe with variables USUBJID, TRCAT, TRLINKID/TRLNKID, TRTESTCD, TRSTRESC,
 #'           TRDTC, TRSPID (if it exists)
-#' @param preproc An optional company specific preprocessing script
-#' @param ... Other arguments passed to methods
 #'
 #' @author Joel Laxamana
 #'
@@ -23,6 +21,7 @@
 #'  TRCAT    = c(1,1,2,2),
 #'  TRTESTCD = c(1,1,2,2),
 #'  TRLINKID = c(1,1,2,2),
+#'  TRGRPID = "Example",
 #'  TRDTC = c(rep("2016-01-01",2), rep("2016-06-01",2)),
 #'  TRSTRESC = c(1,1,2,2),
 #'  TRSPID = "FORMNAME-R:19/L:19XXXX",
@@ -32,7 +31,6 @@
 #' )
 #'
 #' check_tr_dup(TR)
-#' check_tr_dup(TR,preproc=roche_derive_rave_row)
 #' 
 #' TR1 <- TR
 #' TR1$TRSPID <- NULL
@@ -45,7 +43,7 @@
 #' check_tr_dup(TR2)
 #'
 
-check_tr_dup <- function(TR,preproc=identity,...){
+check_tr_dup <- function(TR){
     
     if (TR %lacks_any% c("USUBJID","TRCAT","TRTESTCD","TRDTC","TRSTRESC","VISIT","TRGRPID")){
         
@@ -56,9 +54,6 @@ check_tr_dup <- function(TR,preproc=identity,...){
         fail("TR is missing both the TRLINKID and TRLNKID variables. ")
         
     } else{
-        
-        #Apply company specific preprocessing function
-        TR = preproc(TR,...)
         
         myvars <- c("USUBJID","TRCAT","TRGRPID","TRTESTCD",names(TR)[names(TR) %in% c("TRLINKID","TRLNKID")],
                     # names(TR)[names(TR) %in% "TRSPID"],

--- a/man/check_tr_dup.Rd
+++ b/man/check_tr_dup.Rd
@@ -4,15 +4,11 @@
 \alias{check_tr_dup}
 \title{Check for duplicate TR records}
 \usage{
-check_tr_dup(TR, preproc = identity, ...)
+check_tr_dup(TR)
 }
 \arguments{
 \item{TR}{dataframe with variables USUBJID, TRCAT, TRLINKID/TRLNKID, TRTESTCD, TRSTRESC,
 TRDTC, TRSPID (if it exists)}
-
-\item{preproc}{An optional company specific preprocessing script}
-
-\item{...}{Other arguments passed to methods}
 }
 \description{
 This check looks for duplicate TR records and returns a data frame.
@@ -26,6 +22,7 @@ TREVAL = "INVESTIGATOR" or missing or TREVAL variable does not exist.
  TRCAT    = c(1,1,2,2),
  TRTESTCD = c(1,1,2,2),
  TRLINKID = c(1,1,2,2),
+ TRGRPID = "Example",
  TRDTC = c(rep("2016-01-01",2), rep("2016-06-01",2)),
  TRSTRESC = c(1,1,2,2),
  TRSPID = "FORMNAME-R:19/L:19XXXX",
@@ -35,7 +32,6 @@ TREVAL = "INVESTIGATOR" or missing or TREVAL variable does not exist.
 )
 
 check_tr_dup(TR)
-check_tr_dup(TR,preproc=roche_derive_rave_row)
 
 TR1 <- TR
 TR1$TRSPID <- NULL

--- a/tests/testthat/test-check_tr_dup.R
+++ b/tests/testthat/test-check_tr_dup.R
@@ -9,6 +9,7 @@ test_that("Returns true when no errors present", {
     TRSPID   = c(1,1,2,2),
     TRDTC    = c(1,1,2,2),
     TRSTRESC = c(1,1,2,2),
+    TRGRPID = "Example",
     VISIT = "Visit 1"
   )
   
@@ -29,6 +30,7 @@ test_that("Returns false when errors present", {
     TRSPID   = c(1,1,2,2),
     TRDTC    = c(1,1,2,2),
     TRSTRESC = c(1,1,2,2),
+    TRGRPID = "Example",
     VISIT = "Visit 1"
   )
   
@@ -46,6 +48,7 @@ test_that("Returns false when expected column not present - 1", {
     TRSPID   = c(1,2,2,1),
     TRDTC    = c(1,1,2,2),
     TRSTRESC = c(1,2,2,1),
+    TRGRPID = "Example",
     VISIT = "Visit 1"
   )
   
@@ -66,6 +69,7 @@ test_that("Returns false when expected column not present - 2", {
     TRSPID   = c(1,2,2,1),
     TRDTC    = c(1,1,2,2),
     TRSTRESC = c(1,2,2,1),
+    TRGRPID = "Example",
     VISIT = "Visit 1"
   )
   

--- a/tests/testthat/test-check_tr_dup.R
+++ b/tests/testthat/test-check_tr_dup.R
@@ -8,7 +8,8 @@ test_that("Returns true when no errors present", {
     TRLINKID = c(1,1,2,2),
     TRSPID   = c(1,1,2,2),
     TRDTC    = c(1,1,2,2),
-    TRSTRESC = c(1,1,2,2)
+    TRSTRESC = c(1,1,2,2),
+    VISIT = "Visit 1"
   )
   
   TR <- TR[c(1,3),]
@@ -27,7 +28,8 @@ test_that("Returns false when errors present", {
     TRLINKID = c(1,1,2,2),
     TRSPID   = c(1,1,2,2),
     TRDTC    = c(1,1,2,2),
-    TRSTRESC = c(1,1,2,2)
+    TRSTRESC = c(1,1,2,2),
+    VISIT = "Visit 1"
   )
   
   expect_false(check_tr_dup(TR))
@@ -43,7 +45,8 @@ test_that("Returns false when expected column not present - 1", {
     TRLINKID = c(1,1,2,2),
     TRSPID   = c(1,2,2,1),
     TRDTC    = c(1,1,2,2),
-    TRSTRESC = c(1,2,2,1)
+    TRSTRESC = c(1,2,2,1),
+    VISIT = "Visit 1"
   )
   
   TR$USUBJID <- NULL
@@ -62,7 +65,8 @@ test_that("Returns false when expected column not present - 2", {
     TRLINKID = c(1,1,2,2),
     TRSPID   = c(1,2,2,1),
     TRDTC    = c(1,1,2,2),
-    TRSTRESC = c(1,2,2,1)
+    TRSTRESC = c(1,2,2,1),
+    VISIT = "Visit 1"
   )
   
   TR$TRLINKID <- NULL


### PR DESCRIPTION
@sarabodach this is a PR into your PR.  Here's some thoughts:

- Including TRSPID in the dup variables seems sub optimal - would it only catch a mapping issue or something?  But also trying to add `RAVE` in at the end also isn't perfect - by just merging on variables a guess is made of which form the dup is in.  And the guess is not always right (e.g. the same info can be in indicator vs non indicator form).  Ultimately I decided to leave SPID/RAVE out of this check.
- Duping with VISIT seems to get rid of a lot of records where date duplicate is flagged due to missing date.  While missing dates may be bad its not technically a duplicate if its at different visits.  Checking for missing dates could be a separate check.
- `TRGRPID` seems needed in the dup vars as well

I tried it out on a bunch of datasets.  Let me know what you think, feel free to reject this if you think its off base.